### PR TITLE
Update runtime to 5.15-21.08

### DIFF
--- a/numeric-limits.diff
+++ b/numeric-limits.diff
@@ -1,0 +1,10 @@
+--- a/src/C4Include.h	2018-03-17 02:25:33.000000000 +0900
++++ b/src/C4Include.h	2021-12-09 22:47:04.502059977 +0900
+@@ -51,6 +51,7 @@
+ #include <cstring>
+ #include <ctime>
+ #include <iostream>
++#include <limits>
+ #include <list>
+ #include <map>
+ #include <memory>

--- a/org.openclonk.OpenClonk.json
+++ b/org.openclonk.OpenClonk.json
@@ -50,6 +50,10 @@
 				{
 					"type": "patch",
 					"path": "appstream.diff"
+				},
+				{
+					"type": "patch",
+					"path": "numeric-limits.diff"
 				}
 			],
 			"buildsystem": "cmake",

--- a/org.openclonk.OpenClonk.json
+++ b/org.openclonk.OpenClonk.json
@@ -1,7 +1,7 @@
 {
 	"app-id": "org.openclonk.OpenClonk",
 	"runtime": "org.kde.Platform",
-	"runtime-version": "5.15",
+	"runtime-version": "5.15-21.08",
 	"sdk": "org.kde.Sdk",
 	"command": "openclonk",
 	"rename-desktop-file": "openclonk.desktop",


### PR DESCRIPTION
The 5.15 version of the KDE Runtime is based on the 20.08 version of the Freedesktop Runtime and will stay as-is to keep compatibility.
The 5.15-21.08 version of the KDE Runtime is based on the 21.08 Freedesktop one. The Qt/KDE Libraries are mostyl similar between the two runtimes.

This change is mostly maintenance to keep the base runtime updated.